### PR TITLE
extend declaration-block-order by mixins keyword

### DIFF
--- a/rules/declaration-block-order/README.md
+++ b/rules/declaration-block-order/README.md
@@ -13,6 +13,7 @@ Specify the order of content within declaration blocks.
 Within an order array, you can include:
 
 - keywords:
+	- `mixins` — Less mixins (e. g., `div { .mixin(); }`)
 	- `custom-properties` — Custom properties (e. g., `--property: 10px;`)
 	- `dollar-variables` — Dollar variables (e. g., `$variable`)
 	- `declarations` — CSS declarations (e. g., `display: block`)
@@ -119,7 +120,25 @@ With `"top"`, unspecified elements are expected _before_ any specified propertie
 Given:
 
 ```js
-["custom-properties", "dollar-variables", "declarations", "rules", "at-rules"]
+["mixins", "custom-properties", "dollar-variables", "declarations", "rules", "at-rules"]
+```
+
+The following pattern are considered warnings:
+
+```css
+a {
+	color: pink;
+	.visited(pink);
+}
+```
+
+The following patterns are _not_ considered warnings:
+
+```css
+a {
+	.visited(pink);
+	color: pink;
+}
 ```
 
 The following patterns are considered warnings:

--- a/rules/declaration-block-order/index.js
+++ b/rules/declaration-block-order/index.js
@@ -214,6 +214,7 @@ function createExpectedOrder(input) {
 
 function getDescription(item) {
 	const descriptions = {
+		mixins: 'mixin',
 		'custom-properties': 'custom property',
 		'dollar-variables': '$-variable',
 		declarations: 'declaration',
@@ -259,7 +260,11 @@ function getOrderData(expectedOrder, node) {
 			nodeType = 'declarations';
 		}
 	} else if (node.type === 'rule') {
-		nodeType = 'rules';
+		if (isMixin(node)) {
+			nodeType = 'mixins';
+		} else {
+			nodeType = 'rules';
+		}
 	} else if (node.type === 'atrule') {
 		nodeType = {
 			type: 'at-rule',
@@ -386,6 +391,10 @@ function isStandardSyntaxProperty(property) {
 	return true;
 }
 
+function isMixin(node) {
+	return node.ruleWithoutBody;
+}
+
 function validatePrimaryOption(actualOptions) {
 	// Otherwise, begin checking array options
 	if (!Array.isArray(actualOptions)) {
@@ -396,7 +405,7 @@ function validatePrimaryOption(actualOptions) {
 	// with a "type" property
 	if (!actualOptions.every((item) => {
 		if (_.isString(item)) {
-			return _.includes(['custom-properties', 'dollar-variables', 'declarations', 'rules', 'at-rules'], item);
+			return _.includes(['mixins', 'custom-properties', 'dollar-variables', 'declarations', 'rules', 'at-rules'], item);
 		}
 
 		return _.isPlainObject(item) && !_.isUndefined(item.type);

--- a/rules/declaration-block-order/tests/validate-options.js
+++ b/rules/declaration-block-order/tests/validate-options.js
@@ -49,6 +49,7 @@ testConfig({
 	description: 'valid keywords',
 	valid: true,
 	config: [
+		'mixins',
 		'custom-properties',
 		'dollar-variables',
 		'declarations',


### PR DESCRIPTION
My team have next problem. Config was as follow:
```
  "order/declaration-block-order": [
   "custom-properties",
   "declarations",
   "at-rules",
   "rules"
 ]
```
And follow css code **not** considered warning, but it breaks down styles.

```
.mixin {
  ...
  top: 0;
  ...
}

.class {
  ...
  top: 50%;
  ...
  .mixin();
  .nested_class {
    ...
  }
}
```

We want to see

```
.class {
  ...
  top: 50%;
  ...
}
```

but we get another

```
.class {
  ...
  top: 0;
  ...
}
```

The correct less should look like this
```
.class {
  .mixin();
  ...
  top: 50%;
  ...
  .nested_class {
    ...
  }
}
```
but it considered warnings (Expected declaration to come before rule).

So I added the **mixins** keyword.