### PR TITLE
Fix stylelint link and description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # stylelint-order [![Build Status][ci-img]][ci]
 
-A collection of order related linting rules for [stylelint] (in a form of a plugin).
+A plugin pack of order related linting rules for [stylelint].
 
 ## Installation
 


### PR DESCRIPTION
1. The link wasn't working.
2. We call these "plugin packs".