### PR TITLE
Update `properties-order` docs.

### DIFF
--- a/rules/properties-order/README.md
+++ b/rules/properties-order/README.md
@@ -574,18 +574,16 @@ If `order: "flexible"` is using, for sorting it will be treated as `strict`. It 
 Given:
 
 ```json
-{
-	"properties-order": [
-		{
-			"order": "flexible",
-			"properties": [
-				"color",
-				"font-size",
-				"font-weight"
-			]
-		}
-	]
-}
+[
+	{
+		"order": "flexible",
+		"properties": [
+			"color",
+			"font-size",
+			"font-weight"
+		]
+	}
+]
 ```
 
 Before:


### PR DESCRIPTION
Super small change, but decided to update to match https://github.com/hudochenkov/stylelint-order/blob/master/rules/order/README.md instead of updating to `"order/properties-order"` on `L:578`.