### PR TITLE
Move stylelint from dependencies to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,13 +29,16 @@
   "dependencies": {
     "lodash": "^4.17.4",
     "postcss": "^6.0.7",
-    "postcss-sorting": "^3.0.1",
-    "stylelint": "^8.0.0"
+    "postcss-sorting": "^3.0.1"
   },
   "devDependencies": {
     "eslint": "^3.19.0",
     "eslint-config-hudochenkov": "^1.3.0",
-    "jest": "^20.0.4"
+    "jest": "^20.0.4",
+    "stylelint": "^8.0.0"
+  },
+  "peerDependencies": {
+    "stylelint": "^8.0.0"
   },
   "scripts": {
     "pretest": "eslint .",


### PR DESCRIPTION
If `package.json` is below,

```json
{
  "devDependencies": {
    "stylelint": "^8.0.0",
    "stylelint-config-standard": "^17.0.0",
    "stylelint-order": "0.5.0"
  }
}
```

then two different versions of `stylelint` are installed.

```bash
$ npm install
# ...
$ npm ls | grep stylelint@
├─┬ stylelint@8.0.0
  └─┬ stylelint@7.13.0
```