### PR TITLE
fix properties-alphabetical-order:false

### DIFF
--- a/rules/properties-alphabetical-order/index.js
+++ b/rules/properties-alphabetical-order/index.js
@@ -18,10 +18,7 @@ function rule(actual, options, context) {
 		const validOptions = stylelint.utils.validateOptions(
 			result,
 			ruleName,
-			{
-				actual,
-				possible: _.isBoolean,
-			},
+			{ actual },
 			{
 				actual: options,
 				possible: {


### PR DESCRIPTION
Hi,

#42 propose a workaround, but having properties-alphabetical-order:false activate the rule is not very user friendly.

Fix is easy (based on how boolean value is handled in https://github.com/stylelint/stylelint/blob/master/lib/rules/property-no-vendor-prefix/index.js )
