### PR TITLE
Add emptyLineBeforeUnspecified secondary option.

### DIFF
--- a/rules/properties-order/README.md
+++ b/rules/properties-order/README.md
@@ -18,6 +18,7 @@ This rule ignores variables (`$sass`, `@less`, `--custom-property`).
 * Options
 * Optional secondary options
 	* [`unspecified: "top"|"bottom"|"bottomAlphabetical"|"ignore"`](#unspecified-topbottombottomalphabeticalignore)
+	* [`emptyLineBeforeUnspecified: "always"|"never"`](#emptyLineBeforeUnspecified-alwaysnever)
 	* [`disableFix: true`](#disablefix-true)
 * [Autofixing caveats](#autofixing-caveats)
 
@@ -591,6 +592,54 @@ a {
 	composes: b;
 	align-items: flex-end;
 	left: 0;
+}
+```
+
+### `emptyLineBeforeUnspecified: "always"|"never"`
+
+Default behavior does not enforce the presence of an empty line before an unspecified block of properties.
+
+If `"always"`, the unspecified group must be separated from other properties by an empty newline. If `"never"`, the unspecified group must have no empty lines separating it from other properties.
+
+Given:
+
+```js
+[
+    [
+        "height",
+        "width",
+    ],
+    {
+        unspecified: 'bottom',
+        emptyLineBeforeUnspecified: 'always'
+    }
+]
+```
+
+The following pattern is considered warnings:
+
+```css
+a {
+	height: 1px;
+	width: 2px;
+
+	font-size: 2px;
+	font-weight: bold;
+	color: blue;
+}
+```
+
+The following patterns is *not* considered warnings:
+
+```css
+a {
+	height: 1px;
+	width: 2px;
+
+	font-size: 2px;
+	font-weight: bold;
+
+	color: blue;
 }
 ```
 

--- a/rules/properties-order/checkEmptyLineBefore.js
+++ b/rules/properties-order/checkEmptyLineBefore.js
@@ -18,13 +18,19 @@ module.exports = function checkEmptyLineBefore(firstPropData, secondPropData, sh
 
 	sharedInfo.lastKnownSeparatedGroup = secondPropSeparatedGroup;
 
-	if (firstPropSeparatedGroup !== secondPropSeparatedGroup && !secondPropIsUnspecified) {
+	const betweenGroupsInSpecified =
+		firstPropSeparatedGroup !== secondPropSeparatedGroup && !secondPropIsUnspecified;
+	const startOfUnspecifiedGroup = !firstPropIsUnspecified && secondPropIsUnspecified;
+
+	if (betweenGroupsInSpecified || startOfUnspecifiedGroup) {
 		// Get an array of just the property groups, remove any solo properties
 		const groups = _.reject(sharedInfo.expectation, _.isString);
 
-		// secondProp seperatedGroups start at 2 so we minus 2 to get the 1st item
-		// from our groups array
-		const emptyLineBefore = _.get(groups[secondPropSeparatedGroup - 2], 'emptyLineBefore');
+		const emptyLineBefore = !startOfUnspecifiedGroup
+			? // secondProp seperatedGroups start at 2 so we minus 2 to get the
+			  // 1st item from our groups array
+			  _.get(groups[secondPropSeparatedGroup - 2], 'emptyLineBefore')
+			: sharedInfo.emptyLineBeforeUnspecified;
 
 		if (!hasEmptyLineBefore(secondPropData.node) && emptyLineBefore === 'always') {
 			if (sharedInfo.isFixEnabled) {

--- a/rules/properties-order/index.js
+++ b/rules/properties-order/index.js
@@ -27,6 +27,7 @@ const rule = function(expectation, options, context = {}) {
 				actual: options,
 				possible: {
 					unspecified: ['top', 'bottom', 'ignore', 'bottomAlphabetical'],
+					emptyLineBeforeUnspecified: ['always', 'never'],
 					disableFix: _.isBoolean,
 				},
 				optional: true,
@@ -39,6 +40,7 @@ const rule = function(expectation, options, context = {}) {
 
 		// By default, ignore unspecified properties
 		const unspecified = _.get(options, 'unspecified', 'ignore');
+		const emptyLineBeforeUnspecified = _.get(options, 'emptyLineBeforeUnspecified', '');
 		const disableFix = _.get(options, 'disableFix', false);
 		const isFixEnabled = context.fix && !disableFix;
 
@@ -48,6 +50,7 @@ const rule = function(expectation, options, context = {}) {
 			expectedOrder,
 			expectation,
 			unspecified,
+			emptyLineBeforeUnspecified,
 			messages,
 			ruleName,
 			result,

--- a/rules/properties-order/tests/empty-line-before-unspecified.js
+++ b/rules/properties-order/tests/empty-line-before-unspecified.js
@@ -1,0 +1,144 @@
+const rule = require('..');
+const { ruleName, messages } = rule;
+
+testRule(rule, {
+	ruleName,
+	config: [
+		['height', 'width'],
+		{
+			unspecified: 'bottom',
+			emptyLineBeforeUnspecified: 'always',
+		},
+	],
+	fix: true,
+
+	accept: [
+		{
+			description: '1',
+			code: `
+				a {
+					height: 20px;
+
+					width: 20px;
+
+					font-style: italic;
+				}
+			`,
+		},
+		{
+			description: '2',
+			code: `
+				a {
+					height: 20px;
+					width: 20px;
+
+					font-style: italic;
+				}
+			`,
+		},
+		{
+			description: '3',
+			code: `
+				a {
+					height: 20px;
+
+					font-style: italic;
+				}
+			`,
+		},
+		{
+			description: '4',
+			code: `
+				a {
+					font-style: italic;
+				}
+			`,
+		},
+		{
+			description: '5',
+			code: `
+				a {
+				}
+			`,
+		},
+	],
+
+	reject: [
+		{
+			description: '6',
+			code: `
+				a {
+					height: 20px;
+
+					width: 20px;
+					font-style: italic;
+				}
+			`,
+			fixed: `
+				a {
+					height: 20px;
+
+					width: 20px;
+
+					font-style: italic;
+				}
+			`,
+			message: messages.expectedEmptyLineBefore('font-style'),
+		},
+		{
+			description: '7',
+			code: `
+				a {
+					height: 20px;
+					width: 20px;
+					font-style: italic;
+				}
+			`,
+			fixed: `
+				a {
+					height: 20px;
+					width: 20px;
+
+					font-style: italic;
+				}
+			`,
+			message: messages.expectedEmptyLineBefore('font-style'),
+		},
+		{
+			description: '8',
+			code: `
+				a {
+					height: 20px;
+					font-style: italic;
+				}
+			`,
+			fixed: `
+				a {
+					height: 20px;
+
+					font-style: italic;
+				}
+			`,
+			message: messages.expectedEmptyLineBefore('font-style'),
+		},
+		{
+			description: '9',
+			code: `
+				a {
+					height: 20px;
+					/* other props */
+					font-style: italic;
+				}
+			`,
+			fixed: `
+				a {
+					height: 20px;
+
+					/* other props */
+					font-style: italic;
+				}
+			`,
+			message: messages.expectedEmptyLineBefore('undefined'),
+		},
+	],
+});


### PR DESCRIPTION
* Adds emptyLineBeforeUnspecified as secondary option to
properties-order rule with possible options of 'always' | 'never'.
* Updates README with description of changes.

Resolves #77 