### PR TITLE
Fixing typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A plugin pack of order-related linting rules for [stylelint]. Every rule support
 npm install stylelint --save-dev
 ```
 
-2.  Install `stylelint-oder`:
+2.  Install `stylelint-order`:
 
 ```
 npm install stylelint-order --save-dev


### PR DESCRIPTION
There was a typo in the readme, so I fixed it 

Oder -> Order