### PR TITLE
Add optional name to extended rule object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## Head
 
 * Fixed `order` not reporting warnings, if autofix didn't fix them.
+* Added `name` option to extended rule object to improve error messaging.
 
 ## 4.0.0
 

--- a/rules/order/README.md
+++ b/rules/order/README.md
@@ -131,6 +131,7 @@ Object parameters:
 * `selector`: `string`|`regex`. Selector pattern. A string will be translated into a RegExp — `new RegExp(yourString)` — so _be sure to escape properly_. Examples:
 	* `selector: /^&:[\w-]+$/` matches simple pseudo-classes. E. g., `&:hover`, `&:first-child`. Doesn't match complex pseudo-classes, e. g. `&:not(.is-visible)`.
 	* `selector: /^&::[\w-]+$/` matches pseudo-elements. E. g. `&::before`, `&::placeholder`.
+* `name`: `string`. Selector name (optional). Will be used in error output to help identify extended rule object.
 
 Matches all rules:
 

--- a/rules/order/getDescription.js
+++ b/rules/order/getDescription.js
@@ -35,7 +35,10 @@ module.exports = function getDescription(item) {
 		if (item.type === 'rule') {
 			text = 'rule';
 
-			if (item.selector) {
+			if (item.name) {
+				// Prefer 'name' property for better error messaging
+				text += ` "${item.name}"`;
+			} else if (item.selector) {
 				text += ` with selector matching "${item.selector}"`;
 			}
 		}

--- a/rules/order/tests/index.js
+++ b/rules/order/tests/index.js
@@ -1072,6 +1072,83 @@ testRule({
 
 testRule({
 	ruleName,
+	config: [
+		[
+			{
+				type: 'rule',
+			},
+			{
+				type: 'rule',
+				selector: /^&:\w/,
+				name: 'State',
+			},
+			{
+				type: 'rule',
+				selector: /^&/,
+				name: 'Child',
+			},
+		],
+	],
+	fix: true,
+
+	accept: [
+		{
+			code: `
+				a {
+					b & {}
+					&:hover {}
+					& b {}
+				}
+			`,
+		},
+		{
+			code: `
+				a {
+					b & {}
+					& b {}
+				}
+			`,
+		},
+	],
+
+	reject: [
+		{
+			code: `
+				a {
+					b & {}
+					& b {}
+					&:hover {}
+				}
+			`,
+			fixed: `
+				a {
+					b & {}
+					&:hover {}
+					& b {}
+				}
+			`,
+			message: messages.expected('rule "State"', 'rule "Child"'),
+		},
+		{
+			code: `
+				a {
+					&:hover {}
+					b & {}
+				}
+			`,
+			fixed: `
+				a {
+					b & {}
+					&:hover {}
+				}
+			`,
+			message: messages.expected('rule', 'rule "State"'),
+		},
+	],
+});
+
+testRule({
+	ruleName,
 	syntax: 'less',
 	config: [['custom-properties', 'at-variables', 'declarations', 'rules', 'at-rules']],
 	fix: true,

--- a/rules/order/tests/validate-options.js
+++ b/rules/order/tests/validate-options.js
@@ -58,6 +58,11 @@ testConfig({
 		},
 		{
 			type: 'rule',
+			selector: /^&::\w/,
+			name: 'Pseudo',
+		},
+		{
+			type: 'rule',
 		},
 	],
 });

--- a/rules/order/tests/validate-options.js
+++ b/rules/order/tests/validate-options.js
@@ -271,6 +271,60 @@ testConfig({
 
 testConfig({
 	ruleName,
+	description: 'invalid. name is empty',
+	valid: false,
+	config: [
+		{
+			type: 'rule',
+			name: '',
+		},
+	],
+	message: `Invalid option "[{"type":"rule","name":""}]" for rule ${ruleName}`,
+});
+
+testConfig({
+	ruleName,
+	description: 'invalid. name is not a string',
+	valid: false,
+	config: [
+		{
+			type: 'rule',
+			name: null,
+		},
+	],
+	message: `Invalid option "[{"type":"rule","name":null}]" for rule ${ruleName}`,
+});
+
+testConfig({
+	ruleName,
+	description: 'invalid. selector is valid, but name is invalid',
+	valid: false,
+	config: [
+		{
+			type: 'rule',
+			selector: '^&:hover',
+			name: null,
+		},
+	],
+	message: `Invalid option "[{"type":"rule","selector":"^&:hover","name":null}]" for rule ${ruleName}`,
+});
+
+testConfig({
+	ruleName,
+	description: 'invalid. name is valid, but select is invalid',
+	valid: false,
+	config: [
+		{
+			type: 'rule',
+			selector: null,
+			name: 'Element',
+		},
+	],
+	message: `Invalid option "[{"type":"rule","selector":null,"name":"Element"}]" for rule ${ruleName}`,
+});
+
+testConfig({
+	ruleName,
 	description: 'disableFix true',
 	valid: true,
 	config: [

--- a/rules/order/validatePrimaryOption.js
+++ b/rules/order/validatePrimaryOption.js
@@ -65,6 +65,10 @@ module.exports = function validatePrimaryOption(actualOptions) {
 						(_.isString(item.selector) && item.selector.length) ||
 						_.isRegExp(item.selector);
 				}
+
+				if (result && !_.isUndefined(item.name)) {
+					result = _.isString(item.name) && item.name.length;
+				}
 			}
 
 			return result;


### PR DESCRIPTION
First of all, thanks for this plugin! It's really helpful.

I've added the ability to name an extended rule object. This can improve the user experience by showing a more friendly error message.

Here's an example:

```js
{
  type: 'rule',
  name: 'Pseudo Element',
  selector: /^&::/,
},
{
  type: 'rule',
  name: 'BEM Element',
  selector: /^&__/,
}
```

Instead of this message:

`Expected rule with selector matching "/^&::/" to come before rule with selector matching "/^&__/"`

You would get this message:

`Expected rule "Pseudo Element" to come before rule "BEM Element"`.

I updated the docs, changelog and tests. Please let me know if I missed anything!
