### PR TITLE
Fix typo in properties-alphabetical-order docs

### DIFF
--- a/rules/properties-alphabetical-order/README.md
+++ b/rules/properties-alphabetical-order/README.md
@@ -98,7 +98,7 @@ Disable autofixing. Autofixing is enabled by default if it's enabled in stylelin
 {
 	"order/properties-alphabetical-order": [
 		true,
-		{ "diableFix": true }
+		{ "disableFix": true }
 	]
 }
 ```


### PR DESCRIPTION
copy pasted this and it didn't work 😄 

