### PR TITLE
fix: fix the option validate logic of `rules/properties-alphabetical-…

### DIFF
--- a/rules/properties-alphabetical-order/index.js
+++ b/rules/properties-alphabetical-order/index.js
@@ -13,10 +13,16 @@ function rule(actual, options, context = {}) {
 	return function ruleBody(root, result) {
 		let validOptions = stylelint.utils.validateOptions(result, ruleName, {
 			actual,
-			possible: Boolean,
+			possible: (option) => typeof option === 'boolean',
 		});
 
 		if (!validOptions) {
+			// this means the option is invalid.
+			return;
+		}
+
+		if(!actual) {
+			// this means the option is false.
 			return;
 		}
 


### PR DESCRIPTION
This PR is a bug fix.
Here is my `.stylelintrc.json`
```json
{
  "extends": ["stylelint-config-standard-scss"],
  "plugins": ["stylelint-order"],
  "rules": {
    "order/properties-alphabetical-order": false
  }
}
```
After I run `stylelint`, it threw the error `Invalid Option: Invalid option "false" for rule "order/properties-alphabetical-order"`.
I checked your code, found that `stylelint.utils.validateOptions` threw this (at rules/properties-alphabetical-order/index.js line14)
It seems that you set the `possible` as `Boolean`, and if the option is a falsy value like `false`, `stylelint` will throw the error because the check result is false. So  nobody can turn off the rule.

I think the following code may meet your expectation.
```javascript
let validOptions = stylelint.utils.validateOptions(result, ruleName, {
    actual,
    possible: possible: (option) => typeof option === 'boolean',
});

if (!validOptoins) {
    return;
}

if (!actual) {
    return;
}
```