### PR TITLE
Handle inconsistent spacing after sorting inline `style` properties

### DIFF
--- a/rules/properties-alphabetical-order/index.js
+++ b/rules/properties-alphabetical-order/index.js
@@ -4,6 +4,7 @@ import { checkNode } from './checkNode.js';
 import { namespace } from '../../utils/namespace.js';
 import { getContainingNode } from '../../utils/getContainingNode.js';
 import { isRuleWithNodes } from '../../utils/isRuleWithNodes.js';
+import { formatInlineStyleNode } from '../../utils/formatInlineStyleNode.js';
 
 let ruleName = namespace('properties-alphabetical-order');
 
@@ -42,6 +43,7 @@ export function rule(actual) {
 				}
 
 				sortNodeProperties(node, { order: 'alphabetical' });
+				formatInlineStyleNode(node);
 
 				hasRunFixer = true;
 

--- a/rules/properties-order/checkNodeForOrder.js
+++ b/rules/properties-order/checkNodeForOrder.js
@@ -6,6 +6,7 @@ import { getNodeData } from './getNodeData.js';
 import { createFlatOrder } from './createFlatOrder.js';
 import { ruleName } from './ruleName.js';
 import { messages } from './messages.js';
+import { formatInlineStyleNode } from '../../utils/formatInlineStyleNode.js';
 
 export function checkNodeForOrder({ node, primaryOption, unspecified, result, expectedOrder }) {
 	/*
@@ -77,6 +78,7 @@ export function checkNodeForOrder({ node, primaryOption, unspecified, result, ex
 			order: createFlatOrder(primaryOption),
 			unspecifiedPropertiesPosition: unspecified === 'ignore' ? 'bottom' : unspecified,
 		});
+		formatInlineStyleNode(node);
 
 		hasRunFixer = true;
 

--- a/rules/properties-order/tests/flat.js
+++ b/rules/properties-order/tests/flat.js
@@ -561,7 +561,7 @@ testRule({
 				<!DOCTYPE html>
 				<html>
 				<body>
-					<div style="top: 0;color: tomato;"></div>
+					<div style="top: 0; color: tomato"></div>
 				</body>
 				</html>
 			`,
@@ -624,11 +624,213 @@ testRule({
 				<!DOCTYPE html>
 				<html>
 				<body>
-					<div style="top: 0;color: tomato;"></div>
+					<div style="top: 0; color: tomato"></div>
 				</body>
 				</html>
 			`,
 			message: messages.expected('top', 'color'),
+		},
+		{
+			description: 'trim leading and trailing spaces in inline style while fixing order',
+			code: `
+				<!DOCTYPE html>
+				<html>
+				<body>
+					<div style="  color: tomato;top: 0;   "></div>
+				</body>
+				</html>
+			`,
+			fixed: `
+				<!DOCTYPE html>
+				<html>
+				<body>
+					<div style="top: 0; color: tomato"></div>
+				</body>
+				</html>
+			`,
+			message: messages.expected('top', 'color'),
+		},
+		{
+			description: 'fix multiline inline style value order only',
+			code: `
+				<!DOCTYPE html>
+				<html>
+				<body>
+					<div style="
+						color: tomato;
+						top: 0;
+					"></div>
+				</body>
+				</html>
+			`,
+			fixed: `
+				<!DOCTYPE html>
+				<html>
+				<body>
+					<div style="
+						top: 0;
+						color: tomato;
+					"></div>
+				</body>
+				</html>
+			`,
+			message: messages.expected('top', 'color'),
+		},
+	],
+});
+
+testRule({
+	ruleName,
+	config: [['width', 'height', 'overflow']],
+	customSyntax: 'postcss-html',
+	fix: true,
+
+	reject: [
+		{
+			description:
+				'inline style: full HTML document with four inline styles (wrong order overflow before height)',
+			code: `
+				<!DOCTYPE html>
+				<html>
+				<body>
+					<div style="width: 20px; overflow: hidden; height: 10px;"></div>
+					<div style=" width: 20px;  overflow: hidden;   height: 10px "></div>
+
+					<div
+						style=" width: 20px;
+							overflow: hidden;
+							height: 10px;
+						"
+					></div>
+
+					<button
+						style="
+							width: 20px;
+							overflow: hidden;
+							height: 10px;
+						"
+						type="button"
+					></button>
+				</body>
+				</html>
+			`,
+			fixed: `
+				<!DOCTYPE html>
+				<html>
+				<body>
+					<div style="width: 20px; height: 10px; overflow: hidden"></div>
+					<div style="width: 20px; height: 10px; overflow: hidden"></div>
+
+					<div
+						style="width: 20px;
+							height: 10px;
+							overflow: hidden;
+						"
+					></div>
+
+					<button
+						style="
+							width: 20px;
+							height: 10px;
+							overflow: hidden;
+						"
+						type="button"
+					></button>
+				</body>
+				</html>
+			`,
+			warnings: [
+				{
+					message: messages.expected('height', 'overflow'),
+					line: 5,
+					column: 49,
+					endLine: 5,
+					endColumn: 62,
+				},
+				{
+					message: messages.expected('height', 'overflow'),
+					line: 6,
+					column: 53,
+					endLine: 6,
+					endColumn: 65,
+				},
+				{
+					message: messages.expected('height', 'overflow'),
+					line: 11,
+					column: 8,
+					endLine: 11,
+					endColumn: 21,
+				},
+				{
+					message: messages.expected('height', 'overflow'),
+					line: 19,
+					column: 8,
+					endLine: 19,
+					endColumn: 21,
+				},
+			],
+		},
+	],
+});
+
+testRule({
+	ruleName,
+	config: [
+		[
+			'width',
+			'height',
+			'margin-right',
+			'background-image',
+			'background-repeat',
+			'background-position',
+			'background-size',
+		],
+	],
+	customSyntax: 'postcss-html',
+	fix: true,
+
+	reject: [
+		{
+			description: 'inline style: multiline img with indented property lines',
+			code: `
+				<!DOCTYPE html>
+				<html>
+				<body>
+    <img
+      style="
+        height: 34px;
+        width: 48px;
+        margin-right: 4px;
+        background-image: url('https://placehold.co/600x400');
+        background-repeat: no-repeat;
+        background-position: center;
+        background-size: 16px 16px;
+      "
+      src="https://placehold.co/600x400"
+    />
+				</body>
+				</html>
+			`,
+			fixed: `
+				<!DOCTYPE html>
+				<html>
+				<body>
+    <img
+      style="
+        width: 48px;
+        height: 34px;
+        margin-right: 4px;
+        background-image: url('https://placehold.co/600x400');
+        background-repeat: no-repeat;
+        background-position: center;
+        background-size: 16px 16px;
+      "
+      src="https://placehold.co/600x400"
+    />
+				</body>
+				</html>
+			`,
+			message: messages.expected('width', 'height'),
 		},
 	],
 });

--- a/utils/formatInlineStyleNode.js
+++ b/utils/formatInlineStyleNode.js
@@ -1,0 +1,55 @@
+/**
+ * Normalizes whitespace for postcss-html inline `style` attributes (`source.inline` on Root).
+ * Call after `sortNodeProperties` so `raws` reflect the sorted declarations.
+ *
+ * Rules:
+ * - Each declaration `raws.before`:
+ *     if it contains a newline, keep it unchanged;
+ *     otherwise use `''` for the first declaration
+ *     and ` ` for the rest (single space between inline declarations).
+ * - Root `raws.after`:
+ *     if it contains a newline, keep it unchanged;
+ *     otherwise clear it.
+ * - Single-line `after` (no newline): also clear `root.raws.semicolon` so the last `;` is omitted.
+ */
+
+/**
+ * @param {import('postcss').Root} node — inline-style root from postcss-html
+ */
+export function formatInlineStyleNode(node) {
+	if (node?.type !== 'root' || node.source?.inline !== true || !Array.isArray(node.nodes)) {
+		return;
+	}
+
+	const declarations = node.nodes.filter((child) => child.type === 'decl');
+
+	if (declarations.length === 0) {
+		return;
+	}
+
+	if (!node.raws) {
+		node.raws = {};
+	}
+
+	declarations.forEach((child, index) => {
+		if (!child.raws) {
+			child.raws = {};
+		}
+
+		const before = child.raws.before ?? '';
+
+		if (before.includes('\n')) {
+			return;
+		}
+
+		child.raws.before = index === 0 ? '' : ' ';
+	});
+
+	const after = node.raws.after ?? '';
+
+	node.raws.after = after.includes('\n') ? after : '';
+
+	if (!after.includes('\n')) {
+		node.raws.semicolon = false;
+	}
+}


### PR DESCRIPTION
## Motivation

See #217

## Summary

- Only **inline** `style` attributes are affected; plain `.css` files and `<style>` blocks are unchanged.
- For **multiline** inline styles, existing line breaks are preserved as much as possible so user indentation is not disrupted.
- For **single-line** inline styles, declarations are separated by a single space, leading/trailing whitespace is trimmed, and the **trailing semicolon** is removed.

In short: walk the inline declarations—if a declaration’s `before` text contains a newline, keep it; otherwise use a single space between declarations. If the whole attribute value is effectively **single-line**, strip the trailing semicolon.

**Rationale for removing the trailing semicolon:**

1. [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/style) examples for (single-line) inline styles typically omit a semicolon after the last declaration.
2. Align with common formatters such as **Prettier**, which drop that trailing semicolon.

For concrete examples, see `rules/properties-order/tests/flat.js`.
